### PR TITLE
Workaround for a change in ruby 2.1.1's behavior

### DIFF
--- a/extract-sass-dependencies.rb
+++ b/extract-sass-dependencies.rb
@@ -27,9 +27,9 @@ class DependencyExtractor
     files.map {|f| analyze_file(f) }
   end
 
-  def analyze_file(f, importer = importer)
-    children = checker.send(:dependencies, f, importer).map{|c| analyze_file(*c) }
-    Asset.new(f, importer, children)
+  def analyze_file(f, my_importer = importer)
+    children = checker.send(:dependencies, f, my_importer).map{|c| analyze_file(*c) }
+    Asset.new(f, my_importer, children)
   end
 
   def importer


### PR DESCRIPTION
Ruby 2.1.1 made a change to keyword arguments that broke this script: https://bugs.ruby-lang.org/issues/9593
